### PR TITLE
Allow minimum pinned version of numpy to be customized

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ install:
   - $PIP install .
 
 script:
+  - python setup.py check --restructuredtext
   - cd tests
   - mkdir wheelhouse
-  - autowheel $PLATFORM --output-dir=wheelhouse --no-ignore-existing
+  - autowheel $PLATFORM --output-dir=wheelhouse --build-existing
   - ls wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ install:
 script:
   - cd tests
   - mkdir wheelhouse
-  - autowheel $PLATFORM --output-dir=wheelhouse --ignore-existing
+  - autowheel $PLATFORM --output-dir=wheelhouse --no-ignore-existing
   - ls wheelhouse

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ About
 -----
 
 This package is a wrapper around the
-`cibuildwheel <https://github.com/joerick/cibuildwheel>`_ tool, and makes it
+`cibuildwheel <https://github.com/joerick/cibuildwheel>`__ tool, and makes it
 easy to automate building wheels from PyPI source releases rather than
 for a source repository.
 
@@ -18,15 +18,15 @@ Basic usage
 -----------
 
 To use autowheel, you should first follow the instructions for setting up
-`cibuildwheel <https://github.com/joerick/cibuildwheel>`_, but instead of
+`cibuildwheel <https://github.com/joerick/cibuildwheel>`__, but instead of
 running::
 
-    $PIP install cibuildwheel==0.9.4
+    pip install cibuildwheel==0.9.4
     cibuildwheel --output-dir wheelhouse
 
 You should instead run::
 
-    $PIP install autowheel
+    pip install autowheel
     autowheel platform --output-dir wheelhouse
 
 where platform is one of ``macos``, ``linux``, or ``windows``. In addition,
@@ -58,7 +58,10 @@ The way autowheel works is that it will look at all the releases of the package
 on PyPI that are more recent than the oldest version mentioned in the
 ``autowheel.yml`` file, and for each of them it will determine whether any
 wheels are missing. If so, then wheel are built for all Python versions
-specified, and placed in the output directory.
+specified, and placed in the output directory. To force all wheels to be built
+even if they already exist, use the ``--build-existing`` option::
+
+    autowheel platform --output-dir wheelhouse --build-existing
 
 Note that you can list multiple packages inside a single ``autowheel.yml`` file,
 and you can also list the same package multiple times with different

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 |Travis| |AppVeyor|
-    
+
 About
 -----
 
@@ -13,6 +13,9 @@ platform-specific wheels. If you have a pure-Python package, you can probably
 just build a universal wheel with::
 
     python setup.py bdist_wheel --universal
+
+Basic usage
+-----------
 
 To use autowheel, you should first follow the instructions for setting up
 `cibuildwheel <https://github.com/joerick/cibuildwheel>`_, but instead of
@@ -51,8 +54,27 @@ than the required one will be used - in the above example, version 0.1.1 would
 be built with the same Python versions as 0.1, and 0.3 would be built with the
 same versions as 0.2.
 
-Note that you can also specify a ``before_build`` key with a command that should
-be run before the wheel is built, e.g.::
+The way autowheel works is that it will look at all the releases of the package
+on PyPI that are more recent than the oldest version mentioned in the
+``autowheel.yml`` file, and for each of them it will determine whether any
+wheels are missing. If so, then wheel are built for all Python versions
+specified, and placed in the output directory.
+
+Note that you can list multiple packages inside a single ``autowheel.yml`` file,
+and you can also list the same package multiple times with different
+configuration if needed.
+
+Options
+-------
+
+There are a few options that you can add to the configuration to customize the
+build process, and which we now describe.
+
+before_build
+^^^^^^^^^^^^
+
+You can also specify a ``before_build`` key with a command that should be run
+before the wheel is built, e.g.::
 
     - package_name: fast-histogram
       before_build: pip install numpy==1.12.1
@@ -60,13 +82,74 @@ be run before the wheel is built, e.g.::
         '0.1':
           - cp27
 
-You can list multiple packages inside a single ``autowheel.yml`` file.
+Note that if you want to pin Numpy, you should take a look at the ``pin_numpy``
+option instead.
 
-The way autowheel works is that it will look at all the releases of the package
-on PyPI that are more recent than the oldest version mentioned in the
-``autowheel.yml`` file, and for each of them it will determine whether any
-wheels are missing. If so, then wheel are built for all Python versions
-specified, and placed in the output directory.
+pin_numpy and pin_numpy_min
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Wheels that require Numpy as a build-time dependency are typically built against
+the oldest compatible version of Numpy on each platform and for each Python
+version. Rather than having to figure this out manually, you can simply set
+the ``pin_numpy`` option as follows::
+
+    - package_name: fast-histogram
+      pin_numpy: true
+      python_versions:
+        '0.1':
+          - cp27
+          - cp35
+
+and autowheel will automatically determine the correct Numpy version to pin
+against (it does this by determining the version of the oldest available numpy
+wheels for each platform and python version).
+
+In some cases, this might pick a version of Numpy that is too old for the
+package you are building, so you can specify an absolute minimum version with
+the ``pin_numpy_min`` option::
+
+    - package_name: fast-histogram
+      pin_numpy: true
+      pin_numpy_min: 1.13.0
+      python_versions:
+        '0.1':
+          - cp27
+          - cp35
+
+This means that autowheel will pin Numpy to the oldest compatible version or
+1.13.0, whichever is more recent.
+
+test_command and test_requires
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An important step when building wheels is to make sure that the built package
+works properly. You can specify a test command to run after the build using the
+``test_command`` option::
+
+    - package_name: fast-histogram
+      test_command: pytest --pyargs fast_histogram
+      python_versions:
+        '0.1':
+          - cp27
+          - cp35
+
+In the above case, the ``--pyargs`` ensures that we test the installed version
+of the package rather than the source directory. Note that currently due to the
+way cibuildwheel works, the tests are run in the same environment as the build
+environment, so any build-time dependencies installed will still be available
+(this may change in future).
+
+To install additional dependencies into the test environment (e.g. pytest)
+or to update dependencies that were installed during the build process, you can
+use the ``test_requires`` option::
+
+  - package_name: fast-histogram
+    test_command: pytest --pyargs fast_histogram
+    test_requires: pytest numpy==1.15.4
+    python_versions:
+      '0.1':
+        - cp27
+        - cp35
 
 .. |Travis| image:: https://travis-ci.org/astrofrog/autowheel.svg?branch=master
     :target: https://travis-ci.org/astrofrog/autowheel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ install:
 build_script:
   - cd tests
   - mkdir wheelhouse
-  - autowheel windows32 --output-dir=wheelhouse --ignore-existing
-  - autowheel windows64 --output-dir=wheelhouse --ignore-existing
+  - autowheel windows32 --output-dir=wheelhouse --no-ignore-existing
+  - autowheel windows64 --output-dir=wheelhouse --no-ignore-existing
   - dir wheelhouse
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ install:
 build_script:
   - cd tests
   - mkdir wheelhouse
-  - autowheel windows32 --output-dir=wheelhouse --no-ignore-existing
-  - autowheel windows64 --output-dir=wheelhouse --no-ignore-existing
+  - autowheel windows32 --output-dir=wheelhouse --build-existing
+  - autowheel windows64 --output-dir=wheelhouse --build-existing
   - dir wheelhouse
 
 artifacts:

--- a/autowheel/autowheel.py
+++ b/autowheel/autowheel.py
@@ -18,7 +18,7 @@ from .config import PYTHON_TAGS, PLATFORM_TAGS
 
 
 def process(platform_tag=None, before_build=None, package_name=None,
-            python_versions=None, output_dir=None, ignore_existing=False,
+            python_versions=None, output_dir=None, build_existing=False,
             test_command=None, test_requires=None, pin_numpy=False, pin_numpy_min=None):
 
     print('Processing {package_name}'.format(package_name=package_name))
@@ -86,7 +86,7 @@ def process(platform_tag=None, before_build=None, package_name=None,
         # Determine which ones are missing
         missing = sorted(set(required_pythons) - set(wheels_pythons))
 
-        if not missing and not ignore_existing:
+        if not missing and not build_existing:
             print('all wheels present')
             continue
 
@@ -168,8 +168,8 @@ def process(platform_tag=None, before_build=None, package_name=None,
 @click.command()
 @click.argument('platform', type=click.Choice(['macosx', 'windows32', 'windows64', 'linux32', 'linux64']))
 @click.option('--output-dir', type=click.Path(exists=True), default='.')
-@click.option('--ignore-existing/--no-ignore-existing', default=False)
-def main(platform, output_dir, ignore_existing):
+@click.option('--build-existing/--no-build-existing', default=False)
+def main(platform, output_dir, build_existing):
 
     output_dir = os.path.abspath(output_dir)
 
@@ -186,4 +186,4 @@ def main(platform, output_dir, ignore_existing):
                 test_command=package['test_command'],
                 test_requires=package['test_requires'],
                 output_dir=output_dir,
-                ignore_existing=ignore_existing)
+                build_existing=build_existing)

--- a/autowheel/autowheel.py
+++ b/autowheel/autowheel.py
@@ -18,7 +18,7 @@ from .config import PYTHON_TAGS, PLATFORM_TAGS
 
 def process(platform_tag=None, before_build=None, package_name=None,
             python_versions=None, output_dir=None, ignore_existing=False,
-            test_command=None, test_requires=None, pin_numpy=False):
+            test_command=None, test_requires=None, pin_numpy=False, pin_numpy_min=None):
 
     print('Processing {package_name}'.format(package_name=package_name))
 
@@ -133,6 +133,8 @@ def process(platform_tag=None, before_build=None, package_name=None,
 
                 if pin_numpy:
                     pinned_version = MIN_NUMPY[python_tag][platform_tag]
+                    if pin_numpy_min is not None and LooseVersion(pinned_version) < pin_numpy_min:
+                        pinned_version = pin_numpy_min
                     os.environ['CIBW_BEFORE_BUILD'] = 'pip install numpy=={0}'.format(pinned_version)
                 elif before_build:
                     os.environ['CIBW_BEFORE_BUILD'] = str(before_build)
@@ -165,8 +167,9 @@ def main(platform, output_dir, ignore_existing):
 
     for package in packages:
         process(platform_tag=PLATFORM_TAGS[platform],
-                before_build=package.get('before_build', None),
+                before_build=package.get('before_build'),
                 pin_numpy=package.get('pin_numpy', False),
+                pin_numpy_min=package.get('pin_numpy_min'),
                 package_name=package['package_name'],
                 python_versions=package['python_versions'],
                 test_command=package['test_command'],

--- a/autowheel/autowheel.py
+++ b/autowheel/autowheel.py
@@ -83,12 +83,13 @@ def process(platform_tag=None, before_build=None, package_name=None,
             elif fileinfo['packagetype'] == 'sdist':
                 sdist = fileinfo
 
-        # Determine which ones are missing
-        missing = sorted(set(required_pythons) - set(wheels_pythons))
-
-        if not missing and not build_existing:
-            print('all wheels present')
-            continue
+        if build_existing:
+            missing = sorted(set(required_pythons))
+        else:
+            missing = sorted(set(required_pythons) - set(wheels_pythons))
+            if not missing:
+                print('all wheels present')
+                continue
 
         print('missing wheels:', missing)
 

--- a/tests/autowheel.yml
+++ b/tests/autowheel.yml
@@ -6,3 +6,12 @@
     '0.7':
       - cp27
       - cp36
+
+- package_name: fast-histogram
+  pin_numpy: true
+  pin_numpy_min: 1.13
+  test_command: pytest -p no:warnings --pyargs fast_histogram -k test_non_contiguous
+  test_requires: pytest hypothesis numpy==1.15.4
+  python_versions:
+    '0.7':
+      - cp36

--- a/tests/autowheel.yml
+++ b/tests/autowheel.yml
@@ -9,7 +9,7 @@
 
 - package_name: fast-histogram
   pin_numpy: true
-  pin_numpy_min: 1.13
+  pin_numpy_min: '1.13'
   test_command: pytest -p no:warnings --pyargs fast_histogram -k test_non_contiguous
   test_requires: pytest hypothesis numpy==1.15.4
   python_versions:


### PR DESCRIPTION
Sometimes the minimum version supported by a package is more recent than the oldest available Numpy wheel.